### PR TITLE
Make brokeraddressfilter do endpoint reconcilation asynchronously

### DIFF
--- a/api/kroxylicious-api/kroxylicious-api.iml
+++ b/api/kroxylicious-api/kroxylicious-api.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/InBandAsyncRequestMakingFilter.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/InBandAsyncRequestMakingFilter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.proxy.filter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import org.apache.kafka.common.message.ProduceRequestData;
+import org.apache.kafka.common.message.ProduceResponseData;
+import org.apache.kafka.common.message.ProduceResponseData.TopicProduceResponse;
+import org.apache.kafka.common.message.RequestHeaderData;
+import org.apache.kafka.common.message.ResponseHeaderData;
+import org.apache.kafka.common.protocol.ApiKeys;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.common.protocol.Errors;
+import org.apache.kafka.common.record.CompressionType;
+import org.apache.kafka.common.record.MemoryRecords;
+import org.apache.kafka.common.record.SimpleRecord;
+import org.jetbrains.annotations.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kroxylicious.proxy.config.BaseConfig;
+
+import junit.framework.AssertionFailedError;
+
+/**
+ * A test filter that makes in-band an asynchronous request to the cluster, delaying the forward
+ * until it completes.
+ */
+public class InBandAsyncRequestMakingFilter implements RequestFilter, ResponseFilter {
+
+    private final InBandAsyncRequestMakingFilterConfig config;
+
+    public enum Direction {
+        ON_REQUEST,
+        ON_RESPONSE;
+
+    }
+
+    public static class InBandAsyncRequestMakingFilterConfig extends BaseConfig {
+        /**
+         * The API key that will trigger the async request
+         */
+        private final ApiKeys apiKeyTrigger;
+
+        /**
+         * Whether the asynchronous request should be performed on request, on response or both.
+         */
+        private final Set<Direction> direction;
+
+        /**
+         * Target topic to be used by the asynchronous producer.
+         */
+        private final String topic;
+
+        /**
+         * Message for the producer to send
+         */
+        private final String message;
+
+        @JsonCreator
+        public InBandAsyncRequestMakingFilterConfig(@JsonProperty(value = "apiKeyTrigger", required = true) ApiKeys apiKeyTrigger,
+                                                    @JsonProperty(value = "direction", required = true) Set<Direction> direction,
+                                                    @JsonProperty(value = "topic", required = true) String topic,
+                                                    @JsonProperty(value = "message", required = true) String message) {
+            this.apiKeyTrigger = apiKeyTrigger;
+            this.direction = direction;
+            this.topic = topic;
+            this.message = message;
+        }
+    }
+
+    public InBandAsyncRequestMakingFilter(InBandAsyncRequestMakingFilterConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public CompletionStage<RequestFilterResult> onRequest(ApiKeys apiKey, RequestHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+
+        if (apiKey == config.apiKeyTrigger && config.direction.contains(Direction.ON_REQUEST)) {
+            return doProduceRequest(filterContext).thenCompose(u -> filterContext.forwardRequest(header, body));
+        }
+        else {
+            return filterContext.forwardRequest(header, body);
+        }
+
+    }
+
+    @Override
+    public CompletionStage<ResponseFilterResult> onResponse(ApiKeys apiKey, ResponseHeaderData header, ApiMessage body, KrpcFilterContext filterContext) {
+        if (apiKey == config.apiKeyTrigger && config.direction.contains(Direction.ON_RESPONSE)) {
+            return doProduceRequest(filterContext).thenCompose(u -> filterContext.forwardResponse(header, body));
+        }
+        else {
+            return filterContext.forwardResponse(header, body);
+        }
+    }
+
+    private CompletionStage<CompletionStage<Void>> doProduceRequest(KrpcFilterContext filterContext) {
+        var produceRequestData = createProduceRequest();
+
+        return filterContext.<ProduceResponseData> sendRequest(ProduceRequestData.HIGHEST_SUPPORTED_VERSION, produceRequestData)
+                .thenApply(produceResponseData -> {
+                    if (produceResponseData.responses().size() != produceRequestData.topicData().size()) {
+                        throw new AssertionFailedError("Unexpected number of produce responses");
+                    }
+
+                    var anyError = produceResponseData.responses().stream()
+                            .map(TopicProduceResponse::partitionResponses)
+                            .flatMap(Collection::stream)
+                            .filter(t -> t.errorCode() != Errors.NONE.code())
+                            .findAny();
+
+                    if (anyError.isPresent()) {
+                        throw new AssertionFailedError("Produce was rejected by server: %s".formatted(produceResponseData));
+                    }
+
+                    return null;
+                });
+    }
+
+    @NotNull
+    private ProduceRequestData createProduceRequest() {
+        var partitionProduceData = new ProduceRequestData.PartitionProduceData()
+                .setIndex(0)
+                .setRecords(MemoryRecords.withRecords(CompressionType.NONE,
+                        new SimpleRecord("0".getBytes(StandardCharsets.UTF_8), config.message.getBytes(StandardCharsets.UTF_8))));
+        var topicProduceData = new ProduceRequestData.TopicProduceData()
+                .setName(config.topic)
+                .setPartitionData(List.of(partitionProduceData));
+
+        var produceRequestData = new ProduceRequestData()
+                .setAcks((short) 1);
+        produceRequestData.topicData().add(topicProduceData);
+        return produceRequestData;
+    }
+}

--- a/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
+++ b/integrationtests/src/test/java/io/kroxylicious/proxy/filter/TestFilterContributor.java
@@ -13,6 +13,7 @@ public class TestFilterContributor extends BaseContributor<KrpcFilter> implement
     public static final BaseContributorBuilder<KrpcFilter> FILTERS = BaseContributor.<KrpcFilter> builder()
             .add("FixedClientId", FixedClientIdFilter.FixedClientIdFilterConfig.class, FixedClientIdFilter::new)
             .add("RequestResponseMarking", RequestResponseMarkingFilter.RequestResponseMarkingFilterConfig.class, RequestResponseMarkingFilter::new)
+            .add("InBandAsyncRequestMakingFilter", InBandAsyncRequestMakingFilter.InBandAsyncRequestMakingFilterConfig.class, InBandAsyncRequestMakingFilter::new)
             .add("OutOfBandSend", OutOfBandSendFilter.OutOfBandSendFilterConfig.class, OutOfBandSendFilter::new)
             .add("CompositePrefixingFixedClientId", CompositePrefixingFixedClientIdFilterConfig.class, CompositePrefixingFixedClientIdFilter::new)
             .add("RequestForwardDelaying", RequestForwardDelayingFilter::new)

--- a/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
+++ b/kroxylicious-test-tools/src/test/java/io/kroxylicious/test/tester/KroxyliciousTestersTest.java
@@ -216,9 +216,15 @@ public class KroxyliciousTestersTest {
     }
 
     private static void assertOneRecordConsumedFrom(Consumer<String, String> consumer) {
-        consumer.subscribe(List.of(TOPIC));
-        ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
-        assertEquals(1, records.count());
+        try {
+            consumer.subscribe(List.of(TOPIC));
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofSeconds(10));
+            assertEquals(1, records.count());
+        }
+        finally {
+            consumer.close();
+        }
+
     }
 
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -8,8 +8,8 @@ package io.kroxylicious.proxy.internal;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.message.RequestHeaderData;
 import org.apache.kafka.common.message.ResponseHeaderData;
 import org.apache.kafka.common.protocol.ApiMessage;
@@ -26,6 +26,7 @@ import io.kroxylicious.proxy.filter.FilterAndInvoker;
 import io.kroxylicious.proxy.filter.FilterInvoker;
 import io.kroxylicious.proxy.filter.FilterResult;
 import io.kroxylicious.proxy.filter.KrpcFilter;
+import io.kroxylicious.proxy.frame.DecodedFrame;
 import io.kroxylicious.proxy.frame.DecodedRequestFrame;
 import io.kroxylicious.proxy.frame.DecodedResponseFrame;
 import io.kroxylicious.proxy.frame.OpaqueRequestFrame;
@@ -90,7 +91,7 @@ public class FilterHandler extends ChannelDuplexHandler {
                 return CompletableFuture.completedFuture(null);
             }
             var future = stage.toCompletableFuture();
-            var withTimeout = handleDeferredStage(ctx, future);
+            var withTimeout = handleDeferredStage(ctx, future, decodedFrame);
             var onNettyThread = switchBackToNettyIfRequired(ctx, withTimeout);
             return onNettyThread.whenComplete((requestFilterResult, t) -> {
                 // maybe better to run the whole thing on the netty thread.
@@ -163,13 +164,17 @@ public class FilterHandler extends ChannelDuplexHandler {
         }
     }
 
-    private <T extends FilterResult> CompletableFuture<T> handleDeferredStage(ChannelHandlerContext ctx, CompletableFuture<T> stage) {
+    private <T extends FilterResult> CompletableFuture<T> handleDeferredStage(ChannelHandlerContext ctx, CompletableFuture<T> stage,
+                                                                              DecodedFrame<?, ?> decodedFrame) {
         if (!stage.isDone()) {
             inboundChannel.config().setAutoRead(false);
-            ctx.executor().schedule(() -> {
-                stage.completeExceptionally(new TimeoutException());
+            var timeoutFuture = ctx.executor().schedule(() -> {
+                LOGGER.warn("{}: Filter {} was timed-out whilst processing {} {}", ctx.channel(), filterDescriptor(),
+                        decodedFrame instanceof DecodedRequestFrame ? "request" : "response", decodedFrame.apiKey());
+                stage.completeExceptionally(new TimeoutException("Filter %s was timed-out.".formatted(filterDescriptor())));
             }, timeoutMs, TimeUnit.MILLISECONDS);
             return stage.thenApply(filterResult -> {
+                timeoutFuture.cancel(false);
                 inboundChannel.config().setAutoRead(true);
                 return filterResult;
             });
@@ -219,7 +224,7 @@ public class FilterHandler extends ChannelDuplexHandler {
                 return CompletableFuture.completedFuture(null);
             }
             var future = stage.toCompletableFuture();
-            var withTimeout = handleDeferredStage(ctx, future);
+            var withTimeout = handleDeferredStage(ctx, future, decodedFrame);
             var onNettyThread = switchBackToNettyIfRequired(ctx, withTimeout);
             return onNettyThread.whenComplete((responseFilterResult, t) -> {
                 if (t != null) {

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -70,7 +70,11 @@ public class FilterHandler extends ChannelDuplexHandler {
             writeFuture = doWrite(ctx, msg, promise);
         }
         else {
-            writeFuture = writeFuture.whenComplete((a, b) -> doWrite(ctx, msg, promise));
+            writeFuture = writeFuture.whenComplete((a, b) -> {
+                if (ctx.channel().isOpen()) {
+                    doWrite(ctx, msg, promise);
+                }
+            });
         }
     }
 
@@ -211,7 +215,11 @@ public class FilterHandler extends ChannelDuplexHandler {
             readFuture = doRead(ctx, msg);
         }
         else {
-            readFuture = readFuture.whenComplete((a, b) -> doRead(ctx, msg));
+            readFuture = readFuture.whenComplete((a, b) -> {
+                if (ctx.channel().isOpen()) {
+                    doRead(ctx, msg);
+                }
+            });
         }
     }
 

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -176,6 +176,10 @@ public class FilterHandler extends ChannelDuplexHandler {
             return stage.thenApply(filterResult -> {
                 timeoutFuture.cancel(false);
                 inboundChannel.config().setAutoRead(true);
+                var unused = writeFuture.whenComplete((u, t) -> {
+                    // Ensure any writes pending will be flushed upstream, towards the broker.
+                    ctx.flush();
+                });
                 return filterResult;
             });
         }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/FilterHandler.java
@@ -123,6 +123,9 @@ public class FilterHandler extends ChannelDuplexHandler {
                 }
 
                 if (requestFilterResult.closeConnection()) {
+                    if (requestFilterResult.message() != null) {
+                        ctx.flush();
+                    }
                     filterContext.closeConnection();
                 }
             }).toCompletableFuture().thenApply(filterResult -> null);

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -106,9 +106,9 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
     private CompletionStage<ResponseFilterResult> doReconcileThenForwardResponse(ResponseHeaderData header, ApiMessage data, KrpcFilterContext context,
                                                                                  Map<Integer, HostPort> nodeMap) {
         return reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture()
-                        .thenCompose(u -> {
-                            LOGGER.debug("Endpoint reconciliation complete for virtual cluster {}", virtualCluster);
-                            return context.responseFilterResultBuilder().forward(header, data).completed();
-                        });
+                .thenCompose(u -> {
+                    LOGGER.debug("Endpoint reconciliation complete for virtual cluster {}", virtualCluster);
+                    return context.responseFilterResultBuilder().forward(header, data).completed();
+                });
     }
 }

--- a/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
+++ b/kroxylicious/src/main/java/io/kroxylicious/proxy/internal/filter/BrokerAddressFilter.java
@@ -105,10 +105,10 @@ public class BrokerAddressFilter implements MetadataResponseFilter, FindCoordina
 
     private CompletionStage<ResponseFilterResult> doReconcileThenForwardResponse(ResponseHeaderData header, ApiMessage data, KrpcFilterContext context,
                                                                                  Map<Integer, HostPort> nodeMap) {
-        // https://github.com/kroxylicious/kroxylicious/issues/351
-        // Using synchronous approach for now
-        reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture().join();
-        LOGGER.debug("Endpoint reconciliation complete for virtual cluster {}", virtualCluster);
-        return context.responseFilterResultBuilder().forward(header, data).completed();
+        return reconciler.reconcile(virtualCluster, nodeMap).toCompletableFuture()
+                        .thenCompose(u -> {
+                            LOGGER.debug("Endpoint reconciliation complete for virtual cluster {}", virtualCluster);
+                            return context.responseFilterResultBuilder().forward(header, data).completed();
+                        });
     }
 }


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Evil join die die die

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Make sure all Sonar-Lint warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
